### PR TITLE
introduce reset-css

### DIFF
--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -1,0 +1,26 @@
+html, body, h1, h2, h3, h4, ul, ol, dl, li, dt, dd, p, div, span, img, a, table, tr, th, td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: normal;
+  font-size: 100%;
+  vertical-align:baseline;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+article, header, footer, aside, figure, figcaption, nav, section { 
+  display:block;
+}
+
+body {
+  line-height: 1;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
+ol, ul {
+  list-style: none;
+  list-style-type: none;
+}

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -8,9 +8,12 @@
 }
 
 .top {
-    width: 100%;
-    overflow-x: hidden;
-    margin: 0;
+   min-height: 100%;
+
+   .container {
+       width: 100%;
+       min-width: 980px;
+   }
     
     .header {
         display: flex;

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,7 @@
 <body class="top">
   <div class="container">
     <div class="header">
-    <header>
+      <header>
         <p class="header_title">Masahiro's Portfolio</p>
         <div>
           <ul class="header_menu">

--- a/src/index.html
+++ b/src/index.html
@@ -8,9 +8,9 @@
 </head>
 
 <body class="top">
-  <div>
-    <header class="header">
-      <div>
+  <div class="container">
+    <div  class="header">
+    <header>
         <p class="header_title">Masahiro's Portfolio</p>
         <div>
           <ul class="header_menu">
@@ -31,8 +31,8 @@
             </li>
           </ul>
         </div>
-      </div>
-    </header>
+      </header>
+    </div>
 
     <div>
       <h1 class="body_title">Masahiro's Portfolio</h1>

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
 
 <body class="top">
   <div class="container">
-    <div  class="header">
+    <div class="header">
     <header>
         <p class="header_title">Masahiro's Portfolio</p>
         <div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,1 +1,2 @@
 import "../css/styles.scss";
+import "../css/reset.css";

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -19,7 +19,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.scss/,
+        test: /\.scss|css$/,
         use: [
           "style-loader",
           {


### PR DESCRIPTION
## 関連ISSUE
- #78 

## このPRで達成したい事
- reset-cssを導入してデフォルトのスタイルを消す

## 具体的な変更点
- `src/css`の中に`reset.css`を作成
- cssのバンドルに対応するため`webpack.config.base.js`のtestを変更し`index.js`に`reset.css`をimport

## 見て欲しいところ
- `src/css/reset.css`
- `webpack.config.base.js`のtest、`index.js`のimport
