### PR TITLE
scssを自動整形 できるように設定

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,5 +5,9 @@
         "color-hex-case": ["lower"],
         "unit-no-unknown": [true],
         "no-duplicate-at-import-rules": [true]
-    }
+    },
+    "extends": [
+        "stylelint-config-standard",
+        "stylelint-prettier/recommended"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
     "sass-loader": "^8.0.2",
     "style-loader": "^1.1.3",
     "stylelint": "^13.2.1",
+    "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-recommended-scss": "^4.2.0",
+    "stylelint-config-standard": "^20.0.0",
+    "stylelint-prettier": "^1.1.2",
     "ts-loader": "^7.0.1",
     "typescript": "^3.8.3",
     "url-loader": "^4.0.0",
@@ -54,7 +57,8 @@
     "lint:css": "stylelint ./src/css",
     "precommit": "lint-staged",
     "imagemin": "gulp images",
-    "deploy:gae": "npm run build:prod-gae && cd nginx && gcloud app deploy --quiet"
+    "deploy:gae": "npm run build:prod-gae && cd nginx && gcloud app deploy --quiet",
+    "format": "prettier --write './src/css/styles.scss'"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "precommit": "lint-staged",
     "imagemin": "gulp images",
     "deploy:gae": "npm run build:prod-gae && cd nginx && gcloud app deploy --quiet",
-    "format": "prettier --write './src/css/styles.scss'"
+    "format": "prettier --write './src/css' "
   },
   "husky": {
     "hooks": {

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -1,17 +1,44 @@
-html, body, h1, h2, h3, h4, ul, ol, dl, li, dt, dd, p, div, span, img, a, table, tr, th, td {
+html,
+body,
+h1,
+h2,
+h3,
+h4,
+ul,
+ol,
+dl,
+li,
+dt,
+dd,
+p,
+div,
+span,
+img,
+a,
+table,
+tr,
+th,
+td {
   margin: 0;
   padding: 0;
   border: 0;
   font-weight: normal;
   font-size: 100%;
-  vertical-align:baseline;
+  vertical-align: baseline;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 
-article, header, footer, aside, figure, figcaption, nav, section { 
-  display:block;
+article,
+header,
+footer,
+aside,
+figure,
+figcaption,
+nav,
+section {
+  display: block;
 }
 
 body {
@@ -20,7 +47,8 @@ body {
   -webkit-text-size-adjust: 100%;
 }
 
-ol, ul {
+ol,
+ul {
   list-style: none;
   list-style-type: none;
 }

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -1,204 +1,192 @@
-@import url('https://fonts.googleapis.com/css?family=Anton|Josefin+Sans&display=swap');
+@import url("https://fonts.googleapis.com/css?family=Anton|Josefin+Sans&display=swap");
 
-@media screen and (max-width:480px) { 
-    .top_page_content {
-        display: flex;
-        flex-direction: column;
-    }
+@media screen and (max-width: 480px) {
+  .top_page_content {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 .top {
-   min-height: 100%;
+  min-height: 100%;
 
-   .container {
-       width: 100%;
-       min-width: 980px;
+  .container {
+    width: 100%;
+    min-width: 980px;
 
-       .container_header {
-           box-shadow: 0 0 4px 0 rgba(0,0,0,0.1);
-           height: 60px;
-           min-width: 980px;
-           position: relative;
-           margin-bottom: 56px;
+    .container_header {
+      box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.1);
+      height: 60px;
+      min-width: 980px;
+      position: relative;
+      margin-bottom: 56px;
 
-           .header {
-               height: 60px;
-               position: absolute;
-               right: 0;
-               left: 0;
-               top: 0;
-               background-color: #fff;
-               min-width: 980px;
+      .header {
+        height: 60px;
+        position: absolute;
+        right: 0;
+        left: 0;
+        top: 0;
+        background-color: #fff;
+        min-width: 980px;
 
-               .header_contents {
-                   display: flex;
-                   height: 60px;
-                }
-           
-                .header_title {
-                    display: block;
-                    margin-block-start: 1em;
-                    margin-block-end: 1em;
-                    margin-inline-start: 0px;
-                    margin-inline-end: 0px;
-                    color: #00a4bb;
-                    padding: 8px 8px 7px 8px;
-                    font-weight: bold;
-                }
-
-                .header_menu {
-                    display: block;
-                    margin-block-start: 1em;
-                    margin-block-end: 1em;
-                    margin-inline-start: 0px;
-                    margin-inline-end: 0px;
-                    padding: 8px 8px 7px 8px;
-
-                    .header_menu_ {
-                        display: flex;
-                        list-style: none;
-                        margin: 0;
-            
-                        .header_munu_list {
-                            font-weight: 800;
-                            margin-left: 10px;
-
-                            .header_munu_list_link {
-                                color: #000;
-                                display: block;
-                                padding: 0 8px;
-                                text-decoration: none;
-                            }
-                            .header_munu_list_link:hover {
-                                color: #00a4bb;
-                            }
-                        }
-                    }
-                }
-            }
-   
+        .header_contents {
+          display: flex;
+          height: 60px;
         }
 
-        .container_body {
-            padding: 0;
-            margin: 0 auto;
-            width: 980px;
-            margin-bottom: 64px;
-
-            .wrapper {
-    
-                .wrapper_header {
-                    margin-bottom: 56px;
-    
-                    .wrapper_header_title {
-                        position: relative;
-                        margin-bottom: 18px;
-                    }
-                    .wrapper_header_img {
-                        width: 978px;
-                        height: 398px;
-    
-                        .body_img {
-                            object-fit: cover;
-                            max-width: 100%;
-                            width: 978px;
-                            height: 398px;
-                        }
-                    }
-                }
-    
-                .wrapper_contents {
-                    padding: 40px 40px 108px 0; 
-                                  
-                    .body_main {
-                        margin-bottom: 56px;
-
-                        .body_main_header {
-                            margin-bottom: 40px;
-                            position: relative;
-    
-                            .body_main_title {
-                                font-size: 24px;
-                                font-weight: 700;
-                                display: inline-block;
-                                vertical-align: middle;
-                            }
-                        }
-    
-                        .body_main_contents {
-    
-                            .body_main_contents_list {
-                                display: flex;
-                                list-style: none;
-                                padding: 0;
-                                margin: 0 0 30px -20px;
-                                overflow: h;
-                                overflow: hidden;
-                                width: 680px;
-
-                                .body_main_contents_list_colum {
-                                    display: flex;
-                                    flex-direction: column;
-                                    margin: 0 20px;
-                                    width: 300px;
-                                    
-                                    .body_main_contents_list_colum_img {
-                                        height: auto;
-                                        width: 300px;
-                                        margin-bottom: 10px;
-                                    }
-                                    
-                                    .body_main_contents_list_colum_text {
-                                        font-size: 12px;
-                                        color: rgba(0,0,0,0.4);
-                                        font-weight: 400;
-                                        line-height: 1.33;
-                                        display: inline-block;
-                                    }
-                                }
-                            }
-    
-                            .body_main_contents_text {
-                                margin-bottom: 26px;
-                                font-size: 15px;
-                                line-height: 28px;
-                                font-weight: 400;
-                                color: rgba(0,0,0,0.84);
-                            }
-    
-                        }
-                        
-                        
-                        
-                        
-                    }
-                }
-            }
+        .header_title {
+          display: block;
+          margin-block-start: 1em;
+          margin-block-end: 1em;
+          margin-inline-start: 0;
+          margin-inline-end: 0;
+          color: #00a4bb;
+          padding: 8px 8px 7px 8px;
+          font-weight: bold;
         }
-    }
-    
 
-    .body_title {
-        font-size: 32px;
-        font-weight: 700;
-        line-height: 1.38;
-    }
+        .header_menu {
+          display: block;
+          margin-block-start: 1em;
+          margin-block-end: 1em;
+          margin-inline-start: 0;
+          margin-inline-end: 0;
+          padding: 8px 8px 7px 8px;
 
-    
-    
-    .body_footer {
-        text-align: center;
-        
-        .body_footer_icon {
+          .header_menu_ {
             display: flex;
-            justify-content: center;
             list-style: none;
-            padding: 10px;
-            
-            .body_footer_icon_link {
+            margin: 0;
+
+            .header_munu_list {
+              font-weight: 800;
+              margin-left: 10px;
+
+              .header_munu_list_link {
                 color: #000;
-                padding: 10px;
-            } 
+                display: block;
+                padding: 0 8px;
+                text-decoration: none;
+              }
+              .header_munu_list_link:hover {
+                color: #00a4bb;
+              }
+            }
+          }
         }
+      }
     }
+
+    .container_body {
+      padding: 0;
+      margin: 0 auto;
+      width: 980px;
+      margin-bottom: 64px;
+
+      .wrapper {
+        .wrapper_header {
+          margin-bottom: 56px;
+
+          .wrapper_header_title {
+            position: relative;
+            margin-bottom: 18px;
+          }
+          .wrapper_header_img {
+            width: 978px;
+            height: 398px;
+
+            .body_img {
+              object-fit: cover;
+              max-width: 100%;
+              width: 978px;
+              height: 398px;
+            }
+          }
+        }
+
+        .wrapper_contents {
+          padding: 40px 40px 108px 0;
+
+          .body_main {
+            margin-bottom: 56px;
+
+            .body_main_header {
+              margin-bottom: 40px;
+              position: relative;
+
+              .body_main_title {
+                font-size: 24px;
+                font-weight: 700;
+                display: inline-block;
+                vertical-align: middle;
+              }
+            }
+
+            .body_main_contents {
+              .body_main_contents_list {
+                display: flex;
+                list-style: none;
+                padding: 0;
+                margin: 0 0 30px -20px;
+                overflow: hidden;
+                width: 680px;
+
+                .body_main_contents_list_colum {
+                  display: flex;
+                  flex-direction: column;
+                  margin: 0 20px;
+                  width: 300px;
+
+                  .body_main_contents_list_colum_img {
+                    height: auto;
+                    width: 300px;
+                    margin-bottom: 10px;
+                  }
+
+                  .body_main_contents_list_colum_text {
+                    font-size: 12px;
+                    color: rgba(0, 0, 0, 0.4);
+                    font-weight: 400;
+                    line-height: 1.33;
+                    display: inline-block;
+                  }
+                }
+              }
+
+              .body_main_contents_text {
+                margin-bottom: 26px;
+                font-size: 15px;
+                line-height: 28px;
+                font-weight: 400;
+                color: rgba(0, 0, 0, 0.84);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  .body_title {
+    font-size: 32px;
+    font-weight: 700;
+    line-height: 1.38;
+  }
+
+  .body_footer {
+    text-align: center;
+
+    .body_footer_icon {
+      display: flex;
+      justify-content: center;
+      list-style: none;
+      padding: 10px;
+
+      .body_footer_icon_link {
+        color: #000;
+        padding: 10px;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## 関連ISSUE
#84 

## このPRで達成したい事
- `.scss`の自動整形ができるようにする

## 具体的な変更点
- `style-prettier`の導入
- `package.json`でnpm formatを追加

## 見て欲しいところ
- `prettier`と`stylelint`の設定で`src/css/styles.scss`の自動整形ができるように
- `src/css/styles.scss`のインデントを「4」から「2」に変更