### PR TITLE
メディアクエリを書いてスマホ対応に

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -6,18 +6,53 @@
     flex-direction: column;
   }
 }
+@media screen and (max-width: 415px) {
+  .container_body {
+    max-width: 100%;
+    margin: 0;
+
+    // .body_img {
+    //   object-fit: contain;
+
+    .body_main {
+      max-width: 100%;
+
+      .body_main_contents {
+        max-width: 100%;
+
+        // .body_main_contents_list {
+        //   display: flex;
+        //   flex-direction: column;
+        //   max-width: 100%;
+        //   margin: 0 0 30px 0 !important;
+
+        // .body_main_contents_list_colum {
+        //   margin: 0 !important;
+
+        .body_main_contents_list_colum_text {
+          margin-bottom: 15px;
+        }
+        // }
+        // }
+
+        // .body_main_contents_text {
+        //   font-size: 19px;
+        // }
+      }
+    }
+    // }
+  }
+}
 
 .top {
   min-height: 100%;
 
   .container {
     width: 100%;
-    min-width: 980px;
 
     .container_header {
       box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.1);
       height: 60px;
-      min-width: 980px;
       position: relative;
       margin-bottom: 56px;
 
@@ -28,7 +63,6 @@
         left: 0;
         top: 0;
         background-color: #fff;
-        min-width: 980px;
 
         .header_contents {
           display: flex;
@@ -82,7 +116,6 @@
       padding: 0;
       margin: 0 auto;
       width: 980px;
-      margin-bottom: 64px;
 
       .wrapper {
         .wrapper_header {
@@ -93,14 +126,19 @@
             margin-bottom: 18px;
           }
           .wrapper_header_img {
-            width: 978px;
-            height: 398px;
+            max-width: 100%;
+            width: 100%;
+            height: 400px;
 
             .body_img {
               object-fit: cover;
               max-width: 100%;
-              width: 978px;
-              height: 398px;
+              width: 100%;
+              height: 100%;
+
+              @media screen and (max-width: 415px) {
+                object-fit: contain;
+              }
             }
           }
         }
@@ -129,18 +167,28 @@
                 list-style: none;
                 padding: 0;
                 margin: 0 0 30px -20px;
-                overflow: hidden;
                 width: 680px;
+
+                @media screen and (max-width: 415px) {
+                  display: flex;
+                  flex-direction: column;
+                  max-width: 100%;
+                  margin: 0 0 30px 0;
+                }
 
                 .body_main_contents_list_colum {
                   display: flex;
                   flex-direction: column;
                   margin: 0 20px;
-                  width: 300px;
+                  width: 100%;
+
+                  @media screen and (max-width: 415px) {
+                    margin: 0;
+                  }
 
                   .body_main_contents_list_colum_img {
                     height: auto;
-                    width: 300px;
+                    width: 100%;
                     margin-bottom: 10px;
                   }
 
@@ -160,6 +208,10 @@
                 line-height: 28px;
                 font-weight: 400;
                 color: rgba(0, 0, 0, 0.84);
+
+                @media screen and (max-width: 415px) {
+                  font-size: 19px;
+                }
               }
             }
           }

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <title>My profile</title>
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
 </head>


### PR DESCRIPTION
## 関連ISSUE
#87 

## このPRで達成したい事
- メディアクエリを書いてスマホ対応

## 具体的な変更点
- `src/css/styles.scss`で`@media screen ~`を追記

## 見て欲しいところ
- スマホでの対応ができているかどうか
- メディアクエリで反映されなかったところの原因は何か（詳細下記）

## 詳細
![スクリーンショット 2020-05-02 17 12 58](https://user-images.githubusercontent.com/61375806/80859717-d769a300-8c9d-11ea-8928-6aff27a47db8.png)
- ↑のように、メディアクエリで書いたところよりも元々のスタイルが優先されてしまっているところがいくつかありました。コメントアウトで残しているので何が原因になってしまっているのかも合わせて教えてください。