### PR TITLE
スマホ対応時のUIの修正

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -1,273 +1,217 @@
 @import url("https://fonts.googleapis.com/css?family=Anton|Josefin+Sans&display=swap");
 
-@media screen and (max-width: 480px) {
-  .top_page_content {
-    display: flex;
-    flex-direction: column;
-  }
+.top {
+  min-height: 100%;
+}
+
+.container {
+  width: 100%;
+}
+
+.container_header {
+  box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.1);
+  height: 60px;
+  position: relative;
+  margin-bottom: 56px;
+}
+
+.header {
+  height: 60px;
+  position: absolute;
+  right: 0;
+  left: 0;
+  top: 0;
+  background-color: #fff;
+}
+
+.header_contents {
+  display: flex;
+  height: 60px;
+}
+
+.header_title {
+  display: block;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  color: #00a4bb;
+  padding: 8px 8px 7px 8px;
+  font-weight: bold;
+}
+
+.header_menu {
+  display: block;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding: 8px 8px 7px 8px;
+}
+
+.header_menu_ {
+  display: flex;
+  list-style: none;
+  margin: 0;
+}
+
+.header_munu_list {
+  font-weight: 800;
+  margin-left: 10px;
+}
+
+.header_munu_list_link {
+  color: #000;
+  display: block;
+  padding: 0 8px;
+  text-decoration: none;
+}
+
+.header_munu_list_link:hover {
+  color: #00a4bb;
+}
+
+.container_body {
+  padding: 0;
+  margin: 0 auto;
+  width: 980px;
+}
+
+.wrapper_header {
+  margin-bottom: 56px;
+}
+
+.wrapper_header_title {
+  position: relative;
+  margin-bottom: 18px;
+}
+
+.wrapper_header_img {
+  max-width: 100%;
+  width: 100%;
+  height: 400px;
+}
+
+.body_img {
+  object-fit: cover;
+  max-width: 100%;
+  width: 100%;
+  height: 100%;
+}
+
+.wrapper_contents {
+  padding: 40px 40px 108px 0;
+}
+
+.body_main {
+  margin-bottom: 56px;
+}
+
+.body_main_header {
+  margin-bottom: 40px;
+  position: relative;
+}
+
+.body_main_title {
+  font-size: 24px;
+  font-weight: 700;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.body_main_contents_list {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 30px -20px;
+  width: 680px;
+}
+
+.body_main_contents_list_colum {
+  display: flex;
+  flex-direction: column;
+  margin: 0 20px;
+  width: 100%;
+}
+
+.body_main_contents_list_colum_img {
+  height: auto;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.body_main_contents_list_colum_text {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.4);
+  font-weight: 400;
+  line-height: 1.33;
+  display: inline-block;
+}
+
+.body_main_contents_text {
+  margin-bottom: 26px;
+  font-size: 15px;
+  line-height: 28px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.84);
+}
+
+.body_title {
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.38;
+}
+
+.body_footer {
+  text-align: center;
+}
+
+.body_footer_icon {
+  display: flex;
+  justify-content: center;
+  list-style: none;
+  padding: 10px;
+}
+
+.body_footer_icon_link {
+  color: #000;
+  padding: 10px;
 }
 
 @media screen and (max-width: 415px) {
   .container_body {
     max-width: 100%;
     margin: 0;
-
-    .body_img {
-      object-fit: contain !important;
-    }
-
-    .wrapper_contents {
-      padding: 0 15px !important;
-
-      .body_main {
-        max-width: 100%;
-        padding: 0 0 30px 0 !important;
-        border-bottom: 1px solid #e3e3e3;
-        .body_main_contents {
-          max-width: 100%;
-
-          .body_main_contents_list {
-            max-width: 100%;
-            margin: 0 0 30px 0 !important;
-
-            .body_main_contents_list_colum {
-              margin: 0 !important;
-
-              .body_main_contents_list_colum_text {
-                margin-bottom: 15px;
-              }
-            }
-          }
-          //レスポンシブで変更が反映されない
-          // .body_main_contents_text {
-          //   font-size: 17px;
-          // }
-        }
-      }
-    }
-  }
-}
-
-.top {
-  min-height: 100%;
-
-  .container {
-    width: 100%;
-
-    .container_header {
-      box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.1);
-      height: 60px;
-      position: relative;
-      margin-bottom: 56px;
-
-      .header {
-        height: 60px;
-        position: absolute;
-        right: 0;
-        left: 0;
-        top: 0;
-        background-color: #fff;
-
-        .header_contents {
-          display: flex;
-          height: 60px;
-        }
-
-        .header_title {
-          display: block;
-          margin-block-start: 1em;
-          margin-block-end: 1em;
-          margin-inline-start: 0;
-          margin-inline-end: 0;
-          color: #00a4bb;
-          padding: 8px 8px 7px 8px;
-          font-weight: bold;
-        }
-
-        .header_menu {
-          display: block;
-          margin-block-start: 1em;
-          margin-block-end: 1em;
-          margin-inline-start: 0;
-          margin-inline-end: 0;
-          padding: 8px 8px 7px 8px;
-
-          .header_menu_ {
-            display: flex;
-            list-style: none;
-            margin: 0;
-
-            .header_munu_list {
-              font-weight: 800;
-              margin-left: 10px;
-
-              .header_munu_list_link {
-                color: #000;
-                display: block;
-                padding: 0 8px;
-                text-decoration: none;
-              }
-              .header_munu_list_link:hover {
-                color: #00a4bb;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    .container_body {
-      padding: 0;
-      margin: 0 auto;
-      width: 980px;
-
-      .wrapper {
-        .wrapper_header {
-          margin-bottom: 56px;
-
-          .wrapper_header_title {
-            position: relative;
-            margin-bottom: 18px;
-          }
-          .wrapper_header_img {
-            max-width: 100%;
-            width: 100%;
-            height: 400px;
-
-            .body_img {
-              object-fit: cover;
-              max-width: 100%;
-              width: 100%;
-              height: 100%;
-
-              //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
-              //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
-
-              // @media screen and (max-width: 415px) {
-              //   object-fit: contain;
-              // }
-            }
-          }
-        }
-
-        .wrapper_contents {
-          padding: 40px 40px 108px 0;
-
-          //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
-          //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
-
-          // @media screen and (max-width: 415px) {
-          //   padding: 0 15px;
-          // }
-
-          .body_main {
-            margin-bottom: 56px;
-
-            //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
-            //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
-
-            // @media screen and (max-width: 415px) {
-            //   max-width: 100%;
-            //   margin: 0 0 30px 0;
-            //   border-bottom: 1px solid #e3e3e3;;
-            // }
-
-            .body_main_header {
-              margin-bottom: 40px;
-              position: relative;
-
-              .body_main_title {
-                font-size: 24px;
-                font-weight: 700;
-                display: inline-block;
-                vertical-align: middle;
-              }
-            }
-
-            .body_main_contents {
-              .body_main_contents_list {
-                display: flex;
-                list-style: none;
-                padding: 0;
-                margin: 0 0 30px -20px;
-                width: 680px;
-
-                //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
-                //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
-
-                //@media screen and (max-width: 415px) {
-                //  max-width: 100%;
-                //  margin: 0 0 30px 0 !important;
-                //}
-
-                .body_main_contents_list_colum {
-                  display: flex;
-                  flex-direction: column;
-                  margin: 0 20px;
-                  width: 100%;
-
-                  //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
-                  //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
-
-                  // @media screen and (max-width: 415px) {
-                  //   margin: 0;
-                  // }
-
-                  .body_main_contents_list_colum_img {
-                    height: auto;
-                    width: 100%;
-                    margin-bottom: 10px;
-                  }
-
-                  .body_main_contents_list_colum_text {
-                    font-size: 12px;
-                    color: rgba(0, 0, 0, 0.4);
-                    font-weight: 400;
-                    line-height: 1.33;
-                    display: inline-block;
-                  }
-                }
-              }
-
-              .body_main_contents_text {
-                margin-bottom: 26px;
-                font-size: 15px;
-                line-height: 28px;
-                font-weight: 400;
-                color: rgba(0, 0, 0, 0.84);
-
-                //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
-                //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
-                @media screen and (max-width: 415px) {
-                  font-size: 17px;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
   }
 
-  .body_title {
-    font-size: 32px;
-    font-weight: 700;
-    line-height: 1.38;
+  .body_img {
+    object-fit: contain;
   }
 
-  .body_footer {
-    text-align: center;
+  .wrapper_contents {
+    padding: 0 15px;
+  }
 
-    .body_footer_icon {
-      display: flex;
-      justify-content: center;
-      list-style: none;
-      padding: 10px;
+  .body_main {
+    max-width: 100%;
+    padding: 0 0 30px 0;
+    border-bottom: 1px solid #e3e3e3;
+  }
 
-      .body_footer_icon_link {
-        color: #000;
-        padding: 10px;
-      }
-    }
+  .body_main_contents {
+    max-width: 100%;
+  }
+
+  .body_main_contents_list {
+    max-width: 100%;
+    margin: 0 0 30px 0;
+  }
+
+  .body_main_contents_list_colum {
+    margin: 0;
+  }
+
+  .body_main_contents_list_colum_text {
+    margin-bottom: 15px;
   }
 }

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -6,41 +6,45 @@
     flex-direction: column;
   }
 }
+
 @media screen and (max-width: 415px) {
   .container_body {
     max-width: 100%;
     margin: 0;
 
-    // .body_img {
-    //   object-fit: contain;
+    .body_img {
+      object-fit: contain !important;
+    }
 
-    .body_main {
-      max-width: 100%;
+    .wrapper_contents {
+      padding: 0 15px !important;
 
-      .body_main_contents {
+      .body_main {
         max-width: 100%;
+        padding: 0 0 30px 0 !important;
+        border-bottom: 1px solid #e3e3e3;
+        .body_main_contents {
+          max-width: 100%;
 
-        // .body_main_contents_list {
-        //   display: flex;
-        //   flex-direction: column;
-        //   max-width: 100%;
-        //   margin: 0 0 30px 0 !important;
+          .body_main_contents_list {
+            max-width: 100%;
+            margin: 0 0 30px 0 !important;
 
-        // .body_main_contents_list_colum {
-        //   margin: 0 !important;
+            .body_main_contents_list_colum {
+              margin: 0 !important;
 
-        .body_main_contents_list_colum_text {
-          margin-bottom: 15px;
+              .body_main_contents_list_colum_text {
+                margin-bottom: 15px;
+              }
+            }
+          }
+          //レスポンシブで変更が反映されない
+          // .body_main_contents_text {
+          //   font-size: 17px;
+          // }
         }
-        // }
-        // }
-
-        // .body_main_contents_text {
-        //   font-size: 19px;
-        // }
       }
     }
-    // }
   }
 }
 
@@ -136,9 +140,12 @@
               width: 100%;
               height: 100%;
 
-              @media screen and (max-width: 415px) {
-                object-fit: contain;
-              }
+              //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
+              //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
+
+              // @media screen and (max-width: 415px) {
+              //   object-fit: contain;
+              // }
             }
           }
         }
@@ -146,8 +153,24 @@
         .wrapper_contents {
           padding: 40px 40px 108px 0;
 
+          //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
+          //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
+
+          // @media screen and (max-width: 415px) {
+          //   padding: 0 15px;
+          // }
+
           .body_main {
             margin-bottom: 56px;
+
+            //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
+            //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
+
+            // @media screen and (max-width: 415px) {
+            //   max-width: 100%;
+            //   margin: 0 0 30px 0;
+            //   border-bottom: 1px solid #e3e3e3;;
+            // }
 
             .body_main_header {
               margin-bottom: 40px;
@@ -169,12 +192,13 @@
                 margin: 0 0 30px -20px;
                 width: 680px;
 
-                @media screen and (max-width: 415px) {
-                  display: flex;
-                  flex-direction: column;
-                  max-width: 100%;
-                  margin: 0 0 30px 0;
-                }
+                //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
+                //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
+
+                //@media screen and (max-width: 415px) {
+                //  max-width: 100%;
+                //  margin: 0 0 30px 0 !important;
+                //}
 
                 .body_main_contents_list_colum {
                   display: flex;
@@ -182,9 +206,12 @@
                   margin: 0 20px;
                   width: 100%;
 
-                  @media screen and (max-width: 415px) {
-                    margin: 0;
-                  }
+                  //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
+                  //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
+
+                  // @media screen and (max-width: 415px) {
+                  //   margin: 0;
+                  // }
 
                   .body_main_contents_list_colum_img {
                     height: auto;
@@ -209,8 +236,10 @@
                 font-weight: 400;
                 color: rgba(0, 0, 0, 0.84);
 
+                //一番上の@media screen~{}中で反映されなかったものをここで書くと反映されるようになる
+                //@media screen~{}の中で!importantをつけているプロパティでは全て同じ事象が発生しています
                 @media screen and (max-width: 415px) {
-                  font-size: 19px;
+                  font-size: 17px;
                 }
               }
             }

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -55,19 +55,19 @@
   margin: 0;
 }
 
-.header_munu_list {
+.header_menu_list {
   font-weight: 800;
   margin-left: 10px;
 }
 
-.header_munu_list_link {
+.header_menu_list_link {
   color: #000;
   display: block;
   padding: 0 8px;
   text-decoration: none;
 }
 
-.header_munu_list_link:hover {
+.header_menu_list_link:hover {
   color: #00a4bb;
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -17,18 +17,18 @@
           <p class="header_title">Masahiro's Portfolio</p>
           <div class="header_menu">
             <ul class="header_menu_">
-              <li class="header_munu_list">
-                <a class="header_munu_list_link" href="#about">
+              <li class="header_menu_list">
+                <a class="header_menu_list_link" href="#about">
                   About
                 </a>
               </li>
-              <li class="header_munu_list">
-                <a class="header_munu_list_link" href="#job">
+              <li class="header_menu_list">
+                <a class="header_menu_list_link" href="#job">
                   Job
                 </a>
               </li>
-              <li class="header_munu_list">
-                <a class="header_munu_list_link" href="#hobby">
+              <li class="header_menu_list">
+                <a class="header_menu_list_link" href="#hobby">
                   Hobby
                 </a>
               </li>

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width">
   <title>My profile</title>
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
 </head>


### PR DESCRIPTION
## 関連ISSUE
#87 

## このPRで達成したい事
- レスポンシブが反映されないところの明瞭化
- スマホ対応時のUIの修正

## 具体的な変更点
- レスポンシブが反映されないところをわかりやすくした（詳細：1）
- スマホ対応時した際のUIを少し修正した（詳細：2）

## 見て欲しいところ
- なぜレスポンシブ対応に反映されないところがあるのか
- スマホ対応時にコンテンツごとに`border-bottom`の設定
- スマホ対応時に横の`padding`を設定

## 詳細1
- `src/css/styles.scss`の@media screen~~内で`!important`をつけないとレスポンシブで反映されないところが複数箇所ある
![スクリーンショット 2020-05-03 15 11 13](https://user-images.githubusercontent.com/61375806/80907234-56b7af00-8d50-11ea-9a40-94247beb08fd.png)
  - ↑でコメントアウトしている箇所を戻した場合以下のようになる
![スクリーンショット 2020-05-02 17 12 58](https://user-images.githubusercontent.com/61375806/80907324-28869f00-8d51-11ea-9aee-262e9a5bda83.png)


- @media screen~~ を各セレクターの中で書いた場合はレスポンシブでも反映される
![スクリーンショット 2020-05-03 15 14 54](https://user-images.githubusercontent.com/61375806/80907286-dba2c880-8d50-11ea-8133-2ea92e9479d7.png)

- コメントアウトしている箇所は全て同様の事象が発生しているところ

## 詳細2
- ↓のように、各コンテンツ事の一番下に`border-bottom`をつけて、`padding`もつけることで横にスペースを作った（少しわかりづらくて申し訳ない、、）

![スクリーンショット 2020-05-03 15 32 08](https://user-images.githubusercontent.com/61375806/80907591-54a31f80-8d53-11ea-98e2-81f8630f54d7.png)

![スクリーンショット 2020-05-03 15 33 57](https://user-images.githubusercontent.com/61375806/80907623-84522780-8d53-11ea-95e5-fb8548015333.png)

