### PR TITLE
スマホ対応時の各コンテンツの画像にスライダーを導入

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
+    jquery: true,
   },
   extends: [
     'plugin:react/recommended',
@@ -23,9 +24,11 @@ module.exports = {
   },
   plugins: [
     'react',
-    "prettier"
+    "prettier",
+    'jquery'
   ],
   rules: {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "func-names": 0
   },
 };

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-react-app": "^3.1.2",
+    "eslint-plugin-jquery": "^1.5.1",
+    "flipsnap": "^0.6.3",
     "jquery": "^3.5.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "swiper": "^5.3.8",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11"
   },

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -166,6 +166,7 @@
 
 .body_footer {
   text-align: center;
+  padding-bottom: 20px;
 }
 
 .body_footer_icon {
@@ -207,12 +208,12 @@
   }
 
   .body_main_contents {
-    max-width: 100%;
+    overflow-x: hidden;
   }
 
   .body_main_contents_list {
-    max-width: 100%;
     margin: 0 0 30px 0;
+    width: 600px;
   }
 
   .body_main_contents_list_colum {

--- a/src/index.html
+++ b/src/index.html
@@ -62,7 +62,7 @@
             </a>
   
             <div class="body_main_contents">
-              <ul class="body_main_contents_list">
+              <ul id="about_slide" class="body_main_contents_list">
                 <li class="body_main_contents_list_colum">
                   <img class="body_main_contents_list_colum_img" src="./img/about1.webp" loading="lazy">
                   <span class="body_main_contents_list_colum_text">
@@ -78,7 +78,7 @@
                   </span>
                 </li>
               </ul>
-  
+
               <p class="body_main_contents_text">
                 こんにちは！都内で証券会社に勤めている森永 雅大と申します！岡山県出身で大学は香川大学だったのですが、支店配属が都内になり19年の4月に上京しました。
               </p>
@@ -98,7 +98,7 @@
               </header class="body_main_header">
             </a>
             <div class="body_main_contents">
-              <ul class="body_main_contents_list">
+              <ul id="job_slide" class="body_main_contents_list">
                 <li class="body_main_contents_list_colum">
                   <img class="body_main_contents_list_colum_img" src="./img/job1.webp" loading="lazy">
                   <span class="body_main_contents_list_colum_text">
@@ -136,7 +136,7 @@
               </header>
             </a>
             <div class="body_main_contents">
-              <ul class="body_main_contents_list">
+              <ul  id="hobby_slide" class="body_main_contents_list">
                 <li class="body_main_contents_list_colum">
                   <img class="body_main_contents_list_colum_img" src="./img/hobby1.webp" loading="lazy">
                   <span class="body_main_contents_list_colum_text">

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,2 +1,21 @@
 import "../css/styles.scss";
 import "../css/reset.css";
+
+const $ = require("jquery");
+const Flipsnap = require("flipsnap");
+
+$(function () {
+  Flipsnap("#about_slide", {
+    distance: 280,
+  });
+});
+$(function () {
+  Flipsnap("#job_slide", {
+    distance: 280,
+  });
+});
+$(function () {
+  Flipsnap("#hobby_slide", {
+    distance: 280,
+  });
+});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,18 +4,20 @@ import "../css/reset.css";
 const $ = require("jquery");
 const Flipsnap = require("flipsnap");
 
-$(function () {
-  Flipsnap("#about_slide", {
-    distance: 280,
+if (window.matchMedia("(max-width: 415px)").matches) {
+  $(function () {
+    Flipsnap("#about_slide", {
+      distance: 280,
+    });
   });
-});
-$(function () {
-  Flipsnap("#job_slide", {
-    distance: 280,
+  $(function () {
+    Flipsnap("#job_slide", {
+      distance: 280,
+    });
   });
-});
-$(function () {
-  Flipsnap("#hobby_slide", {
-    distance: 280,
+  $(function () {
+    Flipsnap("#hobby_slide", {
+      distance: 280,
+    });
   });
-});
+}


### PR DESCRIPTION
## 関連ISSUE
#98 
#80 

## このPRで達成したい事
- スマホ対応時の各コンテンツの画像にスライダーを導入する
- footerの位置調整

## 具体的な変更点
- flipsnapというjqueryのpluginを使ってスライダーを導入
- 条件分岐の式を書くことでスマホ対応時にのみスライダーを反映
- eslintの対象にjqueryも追加
- footerの位置を調整

## 見て欲しいところ
- `src/js/index.js`にスライダー導入のためのコードを記載（詳細1）
![スクリーンショット 2020-05-05 16 27 56](https://user-images.githubusercontent.com/61375806/81043554-63253e80-8eed-11ea-93cb-cb0cc61a266e.png)

- footerの位置を調整した（詳細2）
  - 変更前
![スクリーンショット 2020-05-05 0 52 41](https://user-images.githubusercontent.com/61375806/81043639-97006400-8eed-11ea-8f9f-4f2e8ada544f.png)

  - 変更後
![スクリーンショット 2020-05-05 0 55 18](https://user-images.githubusercontent.com/61375806/81043665-a1baf900-8eed-11ea-958e-09421454a053.png)

## 詳細1
- flipsnapというjqueryのpluginを使ってスライダーを導入しました
- 参照サイト：
  - https://qiita.com/ryuji_i3/items/29ced14dc509ca521fd8
  - http://hokaccha.github.io/js-flipsnap/demo.html

## 詳細2
- [細かいところの修正](https://github.com/mm-masahiro/profile-portfolio/pull/106)というPRがマージされる前に変更していたのを失念していてpushしてしまったので、今回のPRの趣旨とはずれた変更が反映されています