### PR TITLE
スライダーをJavaScriptで書き直し

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
-    jquery: true,
   },
   extends: [
     'plugin:react/recommended',
@@ -25,7 +24,6 @@ module.exports = {
   plugins: [
     'react',
     "prettier",
-    'jquery'
   ],
   rules: {
     "prettier/prettier": "error",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-react-app": "^3.1.2",
-    "eslint-plugin-jquery": "^1.5.1",
     "flipsnap": "^0.6.3",
-    "jquery": "^3.5.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "webpack": "^4.42.0",

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -231,7 +231,7 @@ body {
   }
 
   .body_main_contents_list {
-    margin: 0 0 30px 0;
+    margin: 0;
     width: 600px;
   }
 
@@ -241,5 +241,48 @@ body {
 
   .body_main_contents_list_colum_text {
     margin-bottom: 15px;
+  }
+
+  .pointer {
+    text-align: center;
+  }
+
+  .about_select {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 8px;
+    border: 1px solid #000;
+    margin-bottom: 30px;
+  }
+
+  .about_select.current {
+    background: #00a4bb;
+  }
+
+  .job_select {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 8px;
+    border: 1px solid #000;
+    margin-bottom: 30px;
+  }
+
+  .job_select.current {
+    background: #00a4bb;
+  }
+
+  .hobby_select {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 8px;
+    border: 1px solid #000;
+    margin-bottom: 30px;
+  }
+
+  .hobby_select.current {
+    background: #00a4bb;
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -81,6 +81,10 @@
                   </span>
                 </li>
               </ul>
+              <div class="pointer">
+                <span class="about_select current"></span>
+                <span class="about_select"></span>
+              </div>
 
               <p class="body_main_contents_text">
                 こんにちは！都内で証券会社に勤めている森永 雅大と申します！岡山県出身で大学は香川大学だったのですが、支店配属が都内になり19年の4月に上京しました。
@@ -118,6 +122,11 @@
                   </span>
                 </li>
               </ul>
+              <div class="pointer">
+                <span class="job_select current"></span>
+                <span class="job_select"></span>
+              </div>
+
               <p class="body_main_contents_text">
                 2019年4月にみずほ証券（株）に入社しました。都内の支店配属になり、東京という大きなマーケットの中で法人やそのオーナー・社長を主なターゲットとした新規開拓に取り組んでいます。
               </p>
@@ -155,6 +164,11 @@
                   </span>
                 </li>
               </ul>
+              <div class="pointer">
+                <span class="hobby_select current"></span >
+                <span class="hobby_select"></span>
+              </div>
+
               <p class="body_main_contents_text">
                 カフェに行ったり、スポーツをしたり、音楽を聴いたりと色々趣味があります。
               </p>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,30 +5,30 @@ const Flipsnap = require("flipsnap");
 
 function setUpSlider() {
   if (window.matchMedia("(max-width: 415px)").matches) {
-    Flipsnap("#about_slide", { distance: 275 });
-    const aboutSelect = document.querySelectorAll(".about_select");
+    Flipsnap("#about_slide", { distance: 260 });
+    const aboutSelects = document.querySelectorAll(".about_select");
 
     document.addEventListener("fspointmove", function () {
-      for (let i = 0; i < aboutSelect.length; i += 1) {
-        aboutSelect[i].classList.toggle("current");
+      for (let i = 0; i < aboutSelects.length; i += 1) {
+        aboutSelects[i].classList.toggle("current");
       }
     });
 
-    Flipsnap("#job_slide", { distance: 275 });
-    const jobSelect = document.querySelectorAll(".job_select");
+    Flipsnap("#job_slide", { distance: 260 });
+    const jobSelects = document.querySelectorAll(".job_select");
 
     document.addEventListener("fspointmove", function () {
-      for (let i = 0; i < jobSelect.length; i += 1) {
-        jobSelect[i].classList.toggle("current");
+      for (let i = 0; i < jobSelects.length; i += 1) {
+        jobSelects[i].classList.toggle("current");
       }
     });
 
-    Flipsnap("#hobby_slide", { distance: 275 });
-    const hobbySelect = document.querySelectorAll(".hobby_select");
+    Flipsnap("#hobby_slide", { distance: 260 });
+    const hobbySelects = document.querySelectorAll(".hobby_select");
 
     document.addEventListener("fspointmove", function () {
-      for (let i = 0; i < hobbySelect.length; i += 1) {
-        hobbySelect[i].classList.toggle("current");
+      for (let i = 0; i < hobbySelects.length; i += 1) {
+        hobbySelects[i].classList.toggle("current");
       }
     });
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -14,7 +14,7 @@ function setUpSlider() {
       }
     });
 
-    const jobSlide = Flipsnap("#job_slide", { distance: 275 }); // eslint-disable-line no-unused-vars
+    Flipsnap("#job_slide", { distance: 275 });
     const jobSelect = document.querySelectorAll(".job_select");
 
     document.addEventListener("fspointmove", function () {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -23,7 +23,7 @@ function setUpSlider() {
       }
     });
 
-    const hobbySlide = Flipsnap("#hobby_slide", { distance: 275 }); // eslint-disable-line no-unused-vars
+    Flipsnap("#hobby_slide", { distance: 275 });
     const hobbySelect = document.querySelectorAll(".hobby_select");
 
     document.addEventListener("fspointmove", function () {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,7 +5,7 @@ const Flipsnap = require("flipsnap");
 
 function setUpSlider() {
   if (window.matchMedia("(max-width: 415px)").matches) {
-    const aboutSlide = Flipsnap("#about_slide", { distance: 275 }); // eslint-disable-line no-unused-vars
+    Flipsnap("#about_slide", { distance: 275 });
     const aboutSelect = document.querySelectorAll(".about_select");
 
     document.addEventListener("fspointmove", function () {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,25 +1,37 @@
 import "../css/styles.scss";
 import "../css/reset.css";
 
-const $ = require("jquery");
 const Flipsnap = require("flipsnap");
 
-if (window.matchMedia("(max-width: 415px)").matches) {
-  $(function () {
-    Flipsnap("#about_slide", {
-      distance: 280,
+function setUpSlider() {
+  if (window.matchMedia("(max-width: 415px)").matches) {
+    const aboutSlide = Flipsnap("#about_slide", { distance: 275 }); // eslint-disable-line no-unused-vars
+    const aboutSelect = document.querySelectorAll(".about_select");
+
+    document.addEventListener("fspointmove", function () {
+      for (let i = 0; i < aboutSelect.length; i += 1) {
+        aboutSelect[i].classList.toggle("current");
+      }
     });
-  });
-  $(function () {
-    Flipsnap("#job_slide", {
-      distance: 280,
+
+    const jobSlide = Flipsnap("#job_slide", { distance: 275 }); // eslint-disable-line no-unused-vars
+    const jobSelect = document.querySelectorAll(".job_select");
+
+    document.addEventListener("fspointmove", function () {
+      for (let i = 0; i < jobSelect.length; i += 1) {
+        jobSelect[i].classList.toggle("current");
+      }
     });
-  });
-  $(function () {
-    Flipsnap("#hobby_slide", {
-      distance: 280,
+
+    const hobbySlide = Flipsnap("#hobby_slide", { distance: 275 }); // eslint-disable-line no-unused-vars
+    const hobbySelect = document.querySelectorAll(".hobby_select");
+
+    document.addEventListener("fspointmove", function () {
+      for (let i = 0; i < hobbySelect.length; i += 1) {
+        hobbySelect[i].classList.toggle("current");
+      }
     });
-  });
+  }
 }
 
 function setUpCursor() {
@@ -38,6 +50,7 @@ function setUpCursor() {
 }
 
 function init() {
+  setUpSlider();
   setUpCursor();
 }
 


### PR DESCRIPTION
## 関連ISSUE
#116 
## このPRで達成したい事
- jqueryで書いていたスライダーをJavaScriptで書き直しする
- jqueryをuninstallする
- 表示画像を示すポインターの作成
## 具体的な変更点
- jqueryで書いていたスライダーをJavaScriptで書き直し
- `setUpSlider`という関数を作りinitから呼び出すようにした
- jqueryのuninstall
- 表示画像を示すポインターを作成した
## 見て欲しいところ
![スクリーンショット 2020-05-07 0 48 36](https://user-images.githubusercontent.com/61375806/81198512-85f24880-8ffc-11ea-9af3-453584393174.png)
![スクリーンショット 2020-05-07 0 48 18](https://user-images.githubusercontent.com/61375806/81198520-8854a280-8ffc-11ea-9cd4-4fc4f92dd518.png)
- 上の画像のようにスライド時に表示されている画像の場所を示すポインターを作成（詳細）
- `src/js/index.js`でjqueryで書いていたスライダーのコードをJavaScriptで書き直し

## 詳細
- ポインターが、別コンテンツの画像をスライドしても移動してしまうということが今回のpushでは起きてしまっているので、この問題を今後解決しなければいけない
（ex.Jobのコンテンツ内にある画像をスワイプ　→　Jobコンテンツのポインターが動く　→　AboutやHobbyのコンテンツの画像が動いてなくてもポインターのみが動いてしまう）